### PR TITLE
Add action about window

### DIFF
--- a/code/gui/actionabout.cpp
+++ b/code/gui/actionabout.cpp
@@ -1,0 +1,19 @@
+#include "actionabout.h"
+#include "ui_actionabout.h"
+
+ActionAbout::ActionAbout(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::ActionAbout)
+{
+    ui->setupUi(this);
+
+    // make sure github link links to a website
+    ui->textBrowser->setOpenExternalLinks(true);
+
+    setWindowTitle(tr("About"));
+}
+
+ActionAbout::~ActionAbout()
+{
+    delete ui;
+}

--- a/code/gui/actionabout.h
+++ b/code/gui/actionabout.h
@@ -1,0 +1,22 @@
+#ifndef ACTIONABOUT_H
+#define ACTIONABOUT_H
+
+#include <QDialog>
+
+namespace Ui {
+class ActionAbout;
+}
+
+class ActionAbout : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ActionAbout(QWidget *parent = 0);
+    ~ActionAbout();
+
+private:
+    Ui::ActionAbout *ui;
+};
+
+#endif // ACTIONABOUT_H

--- a/code/gui/actionabout.ui
+++ b/code/gui/actionabout.ui
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ActionAbout</class>
+ <widget class="QDialog" name="ActionAbout">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>580</width>
+    <height>369</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QTextBrowser" name="textBrowser">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>561</width>
+     <height>351</height>
+    </rect>
+   </property>
+   <property name="html">
+    <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:14px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:20pt; font-weight:600;&quot;&gt;minotaur&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:600;&quot;&gt;v0.01&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:20px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;minotaur is a software developed by the University of Waterloo NanoRobotics Group for controlling micro-robots. The source code is GPL licensed and available at &lt;/span&gt;&lt;a href=&quot;https://github.com/uwnrg/&quot;&gt;&lt;span style=&quot; font-size:14pt; text-decoration: underline; color:#0000ff;&quot;&gt;UWNRG Github&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:14pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt; color:#000000; background-color:#ffffff;&quot;&gt;List of contributors:&lt;/span&gt;&lt;/p&gt;
+&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; font-size:14pt; color:#000000;&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Sadman Kazi&lt;/li&gt;
+&lt;li style=&quot; font-size:14pt; color:#000000;&quot; style=&quot; margin-top:3px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Tammy Liu&lt;/li&gt;
+&lt;li style=&quot; font-size:14pt; color:#000000;&quot; style=&quot; margin-top:3px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Jeff Niu&lt;/li&gt;
+&lt;li style=&quot; font-size:14pt; color:#000000;&quot; style=&quot; margin-top:3px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;William Zou&lt;/li&gt;
+&lt;li style=&quot; font-size:14pt; color:#000000;&quot; style=&quot; margin-top:3px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ahmed Sabie&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/code/gui/mainwindow.cpp
+++ b/code/gui/mainwindow.cpp
@@ -18,11 +18,13 @@ MainWindow::MainWindow(QWidget *parent, const char *title) :
     actuator_setup_window = new ActuatorSetup(m_actuator, this);
     simulator_window = new SimulatorWindow(m_simulator, this);
     m_simulator->setSimulatorScene(simulator_window->getSimulatorScene());
+    action_about_window = new ActionAbout();
 
     // Setup slot connections
     connect(ui->setup_actuator, SIGNAL(triggered()), this, SLOT(openActuatorSetup()));
     connect(ui->switch_to_actuator_mode, SIGNAL(triggered()), this, SLOT(switchToActuator()));
     connect(ui->switch_to_simulator_mode, SIGNAL(triggered()), this, SLOT(switchToSimulator()));
+    connect(ui->actionAbout, SIGNAL(triggered()), this, SLOT(openActionAbout()));
 
     // setup focus and an event filter to capture key events
     this->installEventFilter(this);
@@ -123,4 +125,8 @@ void MainWindow::switchControllerTo(Controller::Type const type) {
 
 void MainWindow::openActuatorSetup() {
     actuator_setup_window->show();
+}
+
+void MainWindow::openActionAbout() {
+    action_about_window->show();
 }

--- a/code/gui/mainwindow.h
+++ b/code/gui/mainwindow.h
@@ -11,6 +11,7 @@
 #include "../controller/simulator.h"
 #include "actuatorsetup.h"
 #include "simulatorwindow.h"
+#include "actionabout.h"
 
 #define DEFAULT_TITLE "minotaur"
 
@@ -31,6 +32,7 @@ public slots:
     void openActuatorSetup();
     inline void switchToActuator() { switchControllerTo(Controller::Type::ACTUATOR); }
     inline void switchToSimulator() { switchControllerTo(Controller::Type::SIMULATOR); }
+    void openActionAbout();
 
 private slots:
     // Button click events
@@ -43,6 +45,7 @@ private:
     ActuatorSetup *actuator_setup_window;
     SimulatorWindow *simulator_window;
     Controller::Type m_controller_type;
+    ActionAbout *action_about_window;
     std::shared_ptr<Controller> m_controller;
     std::shared_ptr<Actuator> m_actuator;
     std::shared_ptr<Simulator> m_simulator;

--- a/code/gui/mainwindow.ui
+++ b/code/gui/mainwindow.ui
@@ -409,7 +409,7 @@ p, li { white-space: pre-wrap; }
   </action>
   <action name="actionAbout">
    <property name="enabled">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
    <property name="text">
     <string>About</string>

--- a/minotaur.pro
+++ b/minotaur.pro
@@ -31,7 +31,8 @@ SOURCES += \
     code/gui/simulatorwindow.cpp \
     code/utility/vector2i.cpp \
     code/graphics/simulatorscene.cpp \
-    code/graphics/robotgraphicsitem.cpp
+    code/graphics/robotgraphicsitem.cpp \
+    code/gui/actionabout.cpp \
 
 HEADERS  += \
     code/controller/actuator.h \
@@ -44,8 +45,11 @@ HEADERS  += \
     code/gui/simulatorwindow.h \
     code/utility/vector2i.h \
     code/graphics/simulatorscene.h \
-    code/graphics/robotgraphicsitem.h
+    code/graphics/robotgraphicsitem.h \
+    code/gui/actionabout.h \
 
 FORMS += code/gui/mainwindow.ui \
     code/gui/actuatorsetup.ui \
-    code/gui/simulatorwindow.ui
+    code/gui/simulatorwindow.ui \
+    code/gui/actionabout.ui \
+

--- a/minotaur.pro
+++ b/minotaur.pro
@@ -32,8 +32,8 @@ SOURCES += \
     code/utility/vector2i.cpp \
     code/graphics/simulatorscene.cpp \
     code/graphics/robotgraphicsitem.cpp \
-    code/gui/scriptwindow.cpp \
     code/gui/actionabout.cpp \
+    code/gui/scriptwindow.cpp \
     code/script-engine/scriptengine.cpp \
 
 HEADERS  += \
@@ -48,19 +48,12 @@ HEADERS  += \
     code/utility/vector2i.h \
     code/graphics/simulatorscene.h \
     code/graphics/robotgraphicsitem.h \
+    code/gui/actionabout.h \
     code/gui/scriptwindow.h \
     code/script-engine/scriptengine.h \
-    code/gui/actionabout.h \
 
 FORMS += code/gui/mainwindow.ui \
     code/gui/actuatorsetup.ui \
     code/gui/simulatorwindow.ui \
     code/gui/actionabout.ui \
     code/gui/scriptwindow.ui \
-
-TARGET = minotaur
-TEMPLATE = app
-DESTDIR = builds
-
-# Include third party libraries
-include (third-party/qextserialport.pri)


### PR DESCRIPTION
Addresses issue #19 

This is what the about window looks like
![about](https://cloud.githubusercontent.com/assets/16299227/23929212/d2e064f6-08fa-11e7-93a4-20820fd7b8ab.PNG)

The only issue is clicking the hyperlink (this is made through the built-in html of text browswer) make all of text disappears because I get an error "No document for https://github.com/uwnrg/". It seems to be linking locally rather than to the internet. Any ideas?