### PR TITLE
[HF] ERROR collides with windows.h macro

### DIFF
--- a/code/controller/actuator.cpp
+++ b/code/controller/actuator.cpp
@@ -15,7 +15,7 @@ Actuator::Actuator(const QString &serial_port,
         resetDeviceNumber();
     } else {
         Logger::log("ERROR: " + serial_port.toStdString() + " could not be opened! "
-                    + m_serial_port->errorString().toStdString(), Logger::ERROR);
+                    + m_serial_port->errorString().toStdString(), Logger::FATAL);
     }
 }
 
@@ -71,7 +71,7 @@ int Actuator::setSerPort(const QString &serial_port) {
 
     m_serial_port->setPortName(serial_port);
     if (m_serial_port->lastError() != 0) {
-        Logger::log(m_serial_port->errorString().toStdString(), Logger::ERROR);
+        Logger::log(m_serial_port->errorString().toStdString(), Logger::FATAL);
         return -1;
     }
     return 0;
@@ -86,7 +86,7 @@ int Actuator::changeSettings(const PortSettings &settings) {
     m_serial_port->setTimeout(settings.Timeout_Millisec);
 
     if (m_serial_port->lastError() != 0) {
-        Logger::log(m_serial_port->errorString().toStdString(), Logger::ERROR);
+        Logger::log(m_serial_port->errorString().toStdString(), Logger::FATAL);
         return -1;
     }
     return 0;
@@ -115,11 +115,11 @@ void Actuator::move(Vector2i dir, int timer) {
         y_thread.get();
     }
     catch (std::exception &e) {
-        Logger::log(e.what(), Logger::ERROR);
+        Logger::log(e.what(), Logger::FATAL);
         success = false;
     }
     catch (std::string e) {
-        Logger::log(e, Logger::ERROR);
+        Logger::log(e, Logger::FATAL);
         success = false;
     }
     catch (...) {
@@ -132,7 +132,7 @@ void Actuator::move(Vector2i dir, int timer) {
     if (success) {
         Logger::log("Moved " + dir.toString() + " in " + std::to_string(timer) + " milliseconds.", Logger::INFO);
     } else {
-        Logger::log("The movement " + dir.toString() + " could not be completed.", Logger::ERROR);
+        Logger::log("The movement " + dir.toString() + " could not be completed.", Logger::FATAL);
     }
 }
 

--- a/code/controller/controller.cpp
+++ b/code/controller/controller.cpp
@@ -20,7 +20,7 @@ Vector2i Controller::toVec2(Dir dir) {
             vector_dir.x_comp = -1;
             break;
         default:
-            Logger::log("Invalid direction specified for movement: " + std::to_string(dir), Logger::ERROR);
+            Logger::log("Invalid direction specified for movement: " + std::to_string(dir), Logger::FATAL);
             return vector_dir;
     }
     return vector_dir;
@@ -35,7 +35,7 @@ void Controller::invertAxis(Axis axis) {
             m_invert_y *= -1;
             break;
         default:
-            Logger::log("Invalid axis specified for inversion: " + std::to_string(axis), Logger::ERROR);
+            Logger::log("Invalid axis specified for inversion: " + std::to_string(axis), Logger::FATAL);
             break;
     }
 }

--- a/code/gui/scripteditor.cpp
+++ b/code/gui/scripteditor.cpp
@@ -58,12 +58,12 @@ void ScriptEditor::openFile() {
     Logger::log("Opened file: " + file_path.toStdString(), Logger::DEBUG);
 #endif
     if (file_path.split('.', QString::SkipEmptyParts).last() != "py") {
-        Logger::log("Cannot open non-python file", Logger::ERROR);
+        Logger::log("Cannot open non-python file", Logger::FATAL);
         return;
     }
     QFile script_file(file_path);
     if (!script_file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        Logger::log("Error: could not open selected script file", Logger::ERROR);
+        Logger::log("Error: could not open selected script file", Logger::FATAL);
         return;
     }
     QTextStream script_in(&script_file);
@@ -83,7 +83,7 @@ void ScriptEditor::save() {
 #endif
     QFile script_file(m_active_file);
     if (!script_file.open(QIODevice::WriteOnly)) {
-        Logger::log("Error: could not save file", Logger::ERROR);
+        Logger::log("Error: could not save file", Logger::FATAL);
         return;
     }
     QTextStream script_out(&script_file);
@@ -102,12 +102,12 @@ void ScriptEditor::saveAs() {
     Logger::log("Saving to file: " + file_path.toStdString(), Logger::DEBUG);
 #endif
     if (file_path.isEmpty() || file_path.split('.', QString::SkipEmptyParts).last() != "py") {
-        Logger::log("Error: invalid save file", Logger::ERROR);
+        Logger::log("Error: invalid save file", Logger::FATAL);
         return;
     }
     QFile script_file(file_path);
     if (!script_file.open(QIODevice::WriteOnly)) {
-        Logger::log("Error: could not save file", Logger::ERROR);
+        Logger::log("Error: could not save file", Logger::FATAL);
         return;
     }
     QTextStream script_out(&script_file);

--- a/code/gui/scriptwindow.cpp
+++ b/code/gui/scriptwindow.cpp
@@ -82,7 +82,7 @@ void ScriptWindow::closeInterpreter() {
 
 void ScriptWindow::runScript() {
     if (!PythonEngine::getInstance().isReady()) {
-        Logger::log("Error: running script while PyEngine is off", Logger::ERROR);
+        Logger::log("Error: running script while PyEngine is off", Logger::FATAL);
         return;
     }
     std::string script = m_interpreter_text_edit->toPlainText().toStdString();
@@ -112,13 +112,13 @@ void ScriptWindow::processRunFile(const QString &filePath) {
 #endif
     QFile script_file(filePath);
     if (!script_file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        Logger::log("Error: could not open selected script file", Logger::ERROR);
+        Logger::log("Error: could not open selected script file", Logger::FATAL);
         return;
     }
     QTextStream script_in(&script_file);
     std::string script_text = script_in.readAll().toStdString();
     if (!PythonEngine::getInstance().isReady()) {
-        Logger::log("Error: running script while PyEngine is off", Logger::ERROR);
+        Logger::log("Error: running script while PyEngine is off", Logger::FATAL);
         return;
     }
     std::string py_out, py_err;

--- a/code/utility/logger.h
+++ b/code/utility/logger.h
@@ -11,7 +11,7 @@ class Logger {
 public:
     enum LogType {
         INFO,
-        ERROR,
+        FATAL,
         DEBUG,
 
         NUM_LOG_TYPES
@@ -26,7 +26,7 @@ private:
         switch (type) {
             case INFO:
                 return "black";
-            case ERROR:
+            case FATAL:
                 return "red";
             case DEBUG:
                 return "blue";


### PR DESCRIPTION
The enum `ERROR` in `log.h` collides with a macro from `windows.h` sometimes causing a build error (depending on the `windows.h` version)